### PR TITLE
feat: Add Source Layers and Layer Mappings selects

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -10,4 +10,4 @@ export type TableConfigItemValue = Array<{
 	_id: string
 	[key: string]: BasicConfigItemValue
 }>
-export type BasicConfigItemValue = string | number | boolean
+export type BasicConfigItemValue = string | number | boolean | string[]

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import { DeviceType } from 'timeline-state-resolver-types'
 import { ConfigItemValue, TableConfigItemValue } from './common'
 
 export enum ConfigManifestEntryType {
@@ -6,12 +7,8 @@ export enum ConfigManifestEntryType {
 	BOOLEAN = 'boolean',
 	ENUM = 'enum',
 	TABLE = 'table',
-	SELECT = 'select',
-}
-
-export enum ConfigManifestSelectType {
 	SOURCE_LAYERS = 'source_layers',
-	LAYER_MAPPINGS = 'layer_mappings',
+	LAYER_MAPPINGS = 'layer_mappings'
 }
 
 export type BasicConfigManifestEntry =
@@ -19,7 +16,8 @@ export type BasicConfigManifestEntry =
 	| ConfigManifestEntryNumber
 	| ConfigManifestEntryBoolean
 	| ConfigManifestEntryEnum
-	| ConfigManifestEntrySelect
+	| ConfigManifestEntrySourceLayers
+	| ConfigManifestEntryLayerMappings
 
 export type ConfigManifestEntry = BasicConfigManifestEntry | ConfigManifestEntryTable
 
@@ -53,9 +51,16 @@ export interface ConfigManifestEntryTable extends ConfigManifestEntryBase {
 	columns: BasicConfigManifestEntry[]
 	defaultVal: TableConfigItemValue
 }
-export interface ConfigManifestEntrySelect extends ConfigManifestEntryBase {
-	type: ConfigManifestEntryType.SELECT
-	selectType: ConfigManifestSelectType
+export interface ConfigManifestEntrySourceLayers extends ConfigManifestEntryBase {
+	type: ConfigManifestEntryType.SOURCE_LAYERS
 	multiple: boolean
-	defaultVal: string
+	defaultVal: string | string[]
+}
+export interface ConfigManifestEntryLayerMappings extends ConfigManifestEntryBase {
+	type: ConfigManifestEntryType.LAYER_MAPPINGS
+	multiple: boolean
+	filters?: {
+		deviceTypes?: DeviceType[]
+	}
+	defaultVal: string | string[]
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import { DeviceType } from 'timeline-state-resolver-types'
 import { ConfigItemValue, TableConfigItemValue } from './common'
+import { SourceLayerType } from './content'
 
 export enum ConfigManifestEntryType {
 	STRING = 'string',
@@ -54,6 +55,9 @@ export interface ConfigManifestEntryTable extends ConfigManifestEntryBase {
 export interface ConfigManifestEntrySourceLayers extends ConfigManifestEntryBase {
 	type: ConfigManifestEntryType.SOURCE_LAYERS
 	multiple: boolean
+	filters?: {
+		sourceLayerTypes?: SourceLayerType[]
+	}
 	defaultVal: string | string[]
 }
 export interface ConfigManifestEntryLayerMappings extends ConfigManifestEntryBase {

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,13 @@ export enum ConfigManifestEntryType {
 	NUMBER = 'number',
 	BOOLEAN = 'boolean',
 	ENUM = 'enum',
-	TABLE = 'table'
+	TABLE = 'table',
+	SELECT = 'select',
+}
+
+export enum ConfigManifestSelectType {
+	SOURCE_LAYERS = 'source_layers',
+	LAYER_MAPPINGS = 'layer_mappings',
 }
 
 export type BasicConfigManifestEntry =
@@ -13,6 +19,7 @@ export type BasicConfigManifestEntry =
 	| ConfigManifestEntryNumber
 	| ConfigManifestEntryBoolean
 	| ConfigManifestEntryEnum
+	| ConfigManifestEntrySelect
 
 export type ConfigManifestEntry = BasicConfigManifestEntry | ConfigManifestEntryTable
 
@@ -45,4 +52,10 @@ export interface ConfigManifestEntryTable extends ConfigManifestEntryBase {
 	type: ConfigManifestEntryType.TABLE
 	columns: BasicConfigManifestEntry[]
 	defaultVal: TableConfigItemValue
+}
+export interface ConfigManifestEntrySelect extends ConfigManifestEntryBase {
+	type: ConfigManifestEntryType.SELECT
+	selectType: ConfigManifestSelectType
+	multiple: boolean
+	defaultVal: string
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ export enum ConfigManifestEntryType {
 	BOOLEAN = 'boolean',
 	ENUM = 'enum',
 	TABLE = 'table',
+	SELECT = 'select',
 	SOURCE_LAYERS = 'source_layers',
 	LAYER_MAPPINGS = 'layer_mappings'
 }
@@ -17,8 +18,12 @@ export type BasicConfigManifestEntry =
 	| ConfigManifestEntryNumber
 	| ConfigManifestEntryBoolean
 	| ConfigManifestEntryEnum
-	| ConfigManifestEntrySourceLayers
-	| ConfigManifestEntryLayerMappings
+	| ConfigManifestEntrySelectFromOptions<true>
+	| ConfigManifestEntrySelectFromOptions<false>
+	| ConfigManifestEntrySourceLayers<true>
+	| ConfigManifestEntrySourceLayers<false>
+	| ConfigManifestEntryLayerMappings<true>
+	| ConfigManifestEntryLayerMappings<false>
 
 export type ConfigManifestEntry = BasicConfigManifestEntry | ConfigManifestEntryTable
 
@@ -57,19 +62,29 @@ export interface ConfigManifestEntryTable extends ConfigManifestEntryBase {
 	>
 	defaultVal: TableConfigItemValue
 }
-export interface ConfigManifestEntrySourceLayers extends ConfigManifestEntryBase {
+
+interface ConfigManifestEntrySelectBase<Multiple extends boolean> extends ConfigManifestEntryBase {
+	defaultVal: Multiple extends true ? string[] : string
+	multiple: Multiple
+}
+
+export interface ConfigManifestEntrySelectFromOptions<Multiple extends boolean>
+	extends ConfigManifestEntrySelectBase<Multiple> {
+	type: ConfigManifestEntryType.SELECT
+	options: string[]
+}
+
+export interface ConfigManifestEntrySourceLayers<Multiple extends boolean>
+	extends ConfigManifestEntrySelectBase<Multiple> {
 	type: ConfigManifestEntryType.SOURCE_LAYERS
-	multiple: boolean
 	filters?: {
 		sourceLayerTypes?: SourceLayerType[]
 	}
-	defaultVal: string | string[]
 }
-export interface ConfigManifestEntryLayerMappings extends ConfigManifestEntryBase {
+export interface ConfigManifestEntryLayerMappings<Multiple extends boolean>
+	extends ConfigManifestEntrySelectBase<Multiple> {
 	type: ConfigManifestEntryType.LAYER_MAPPINGS
-	multiple: boolean
 	filters?: {
 		deviceTypes?: DeviceType[]
 	}
-	defaultVal: string | string[]
 }


### PR DESCRIPTION
This PR adds two config manifest entry types:

- `ConfigManifestEntrySourceLayers` for choosing from available source layers, which optionally can be filtered by `SourceLayerType`
- `ConfigManifestEntryLayerMappings` for choosing from available layer mappings, which optionally can be filtered by `DeviceType`

Entries of both types can be either single or multiple choice.