### PR TITLE
feat: Add ignoreMediaObjectStatus to graphics

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -106,6 +106,7 @@ export interface GraphicsContent extends BaseContent {
 	templateData?: object
 	metadata?: MetadataElement[]
 	timelineObjects: TimelineObjectCoreExt[]
+	ignoreMediaObjectStatus?: boolean
 }
 
 export interface NoraPayload {


### PR DESCRIPTION
This PR adds `ignoreMediaObjectStatus` property to GraphicsContent, analogous to the one in VTContent, as some graphics can have their status reported e.g. by the VizMSE Device.